### PR TITLE
Rename Www-Authenticate header name to www-authenticate

### DIFF
--- a/lib/plug_auth/authentication/basic.ex
+++ b/lib/plug_auth/authentication/basic.ex
@@ -58,7 +58,7 @@ defmodule PlugAuth.Authentication.Basic do
 
   defp halt_with_login(conn, realm, error) do
     conn 
-    |> put_resp_header("Www-Authenticate", ~s{Basic realm="#{realm}"})
+    |> put_resp_header("www-authenticate", ~s{Basic realm="#{realm}"})
     |> halt_with_error(error)
   end
 end

--- a/test/plug_auth/authentication/basic_test.exs
+++ b/test/plug_auth/authentication/basic_test.exs
@@ -19,7 +19,7 @@ defmodule PlugAuth.Authentication.Basic.Test do
 
   defp assert_unauthorized(conn, realm) do
     assert conn.status == 401
-    assert get_resp_header(conn, "Www-Authenticate") == [~s{Basic realm="#{realm}"}]
+    assert get_resp_header(conn, "www-authenticate") == [~s{Basic realm="#{realm}"}]
     refute conn.assigns[:authenticated_user]
   end
 


### PR DESCRIPTION
I get this error when trying to use this package:

![image](https://cloud.githubusercontent.com/assets/464900/8255845/e9d862c2-1670-11e5-9f7c-40ade9473f00.png)

This pull request fixes the error! :smile: 
