### PR TITLE
Support for custom CredentialStores

### DIFF
--- a/lib/plug_auth/authentication/basic.ex
+++ b/lib/plug_auth/authentication/basic.ex
@@ -5,11 +5,16 @@ defmodule PlugAuth.Authentication.Basic do
       plug PlugAuth.Authentication.Basic, realm: "Secret world"
 
     to your pipeline. This module is derived from https://github.com/lexmag/blaguth
-  """ 
+  """
 
   @behaviour Plug
   import Plug.Conn
   import PlugAuth.Authentication.Utils
+
+  def init(opts) do
+    credential_store = Keyword.get(opts, :store) || PlugAuth.CredentialStore
+    %{store: credential_store}
+  end
 
   @doc """
     Add the credentials for a `user` and `password` combination. `user_data` can be any term but must not be `nil`.
@@ -57,7 +62,7 @@ defmodule PlugAuth.Authentication.Basic do
   defp assert_creds({conn, user_data}, _, _), do: assign_user_data(conn, user_data)
 
   defp halt_with_login(conn, realm, error) do
-    conn 
+    conn
     |> put_resp_header("www-authenticate", ~s{Basic realm="#{realm}"})
     |> halt_with_error(error)
   end

--- a/lib/plug_auth/authentication/token.ex
+++ b/lib/plug_auth/authentication/token.ex
@@ -10,14 +10,14 @@ defmodule PlugAuth.Authentication.Token do
 
     or
 
-      plug PlugAuth.Authentication.Token, source: :header, param: "X-Auth-Token"    
+      plug PlugAuth.Authentication.Token, source: :header, param: "X-Auth-Token"
 
     or
 
       plug PlugAuth.Authentication.Token, source: { module, function, ["my_param"]} end
 
     to your pipeline.
-  """ 
+  """
 
   @behaviour Plug
   import Plug.Conn

--- a/lib/plug_auth/credential_behaviour.ex
+++ b/lib/plug_auth/credential_behaviour.ex
@@ -5,5 +5,5 @@ defmodule PlugAuth.CredentialBehaviour do
 
   defcallback put_credentials(HashDict.t, any) :: any
 
-  defcallback delete_credentials(HashDic.t) :: any
+  defcallback delete_credentials(HashDict.t) :: any
 end

--- a/lib/plug_auth/credential_behaviour.ex
+++ b/lib/plug_auth/credential_behaviour.ex
@@ -2,8 +2,4 @@ defmodule PlugAuth.CredentialBehaviour do
   use Behaviour
 
   defcallback get_user_data(HashDict.t) :: any
-
-  defcallback put_credentials(HashDict.t, any) :: any
-
-  defcallback delete_credentials(HashDict.t) :: any
 end

--- a/lib/plug_auth/credential_behaviour.ex
+++ b/lib/plug_auth/credential_behaviour.ex
@@ -1,0 +1,11 @@
+defmodule PlugAuth.CredentialBehaviour do
+  use Behaviour
+
+  defcallback start_link() :: any
+
+  defcallback get_user_data(HashDict.t) :: any
+
+  defcallback put_credentials(HashDict.t, any) :: any
+
+  defcallback delete_credentials(HashDic.t) :: any
+end

--- a/lib/plug_auth/credential_behaviour.ex
+++ b/lib/plug_auth/credential_behaviour.ex
@@ -1,8 +1,6 @@
 defmodule PlugAuth.CredentialBehaviour do
   use Behaviour
 
-  defcallback start_link() :: any
-
   defcallback get_user_data(HashDict.t) :: any
 
   defcallback put_credentials(HashDict.t, any) :: any

--- a/lib/plug_auth/credential_store.ex
+++ b/lib/plug_auth/credential_store.ex
@@ -1,4 +1,6 @@
 defmodule PlugAuth.CredentialStore do
+  @behaviour PlugAuth.CredentialBehaviour
+  
   @doc """
   Starts a new credentials store.
   """
@@ -18,7 +20,7 @@ defmodule PlugAuth.CredentialStore do
   """
   def put_credentials(credentials, user_data) do
     Agent.update(__MODULE__, &HashDict.put(&1, credentials, user_data))
-  end  
+  end
 
   @doc """
   Deletes `credentials` from the store.

--- a/test/plug_auth/authentication/basic_with_store_test.exs
+++ b/test/plug_auth/authentication/basic_with_store_test.exs
@@ -9,10 +9,6 @@ defmodule PlugAuth.Authentication.BasicWithStore.Test do
       valid? = (key == Base.encode64("Admin:SecretPass"))
       if valid?, do: %{role: :admin}, else: nil
     end
-
-    def put_credentials(_key, _value), do: :ok
-
-    def delete_credentials(_key), do: %{role: :admin}
   end
 
   defmodule TestPlug do

--- a/test/plug_auth/authentication/basic_with_store_test.exs
+++ b/test/plug_auth/authentication/basic_with_store_test.exs
@@ -1,0 +1,77 @@
+defmodule PlugAuth.Authentication.BasicWithStore.Test do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  defmodule TestStore do
+    @behaviour PlugAuth.CredentialBehaviour
+
+    def get_user_data(key) do
+      valid? = (key == Base.encode64("Admin:SecretPass"))
+      if valid?, do: %{role: :admin}, else: nil
+    end
+
+    def put_credentials(_key, _value), do: :ok
+
+    def delete_credentials(_key), do: %{role: :admin}
+  end
+
+  defmodule TestPlug do
+    use Plug.Builder
+    import Plug.Conn
+
+    plug PlugAuth.Authentication.Basic, realm: "Secret", store: TestStore
+    plug :index
+
+    defp index(conn, _opts), do: send_resp(conn, 200, "Authorized")
+  end
+
+  defp call(plug, headers) do
+    conn(:get, "/", [], headers: headers) |> plug.call([])
+  end
+
+  defp assert_unauthorized(conn, realm) do
+    assert conn.status == 401
+    assert get_resp_header(conn, "www-authenticate") == [~s{Basic realm="#{realm}"}]
+    refute conn.assigns[:authenticated_user]
+  end
+
+  defp assert_authorized(conn, content) do
+    assert conn.status == 200
+    assert conn.resp_body == content
+    assert conn.assigns[:authenticated_user] == %{role: :admin}
+  end
+
+  defp auth_header(creds) do
+    {"authorization", "Basic #{Base.encode64(creds)}"}
+  end
+
+  test "request without credentials" do
+    conn = call(TestPlug, [])
+    assert_unauthorized conn, "Secret"
+  end
+
+  test "request with invalid user" do
+    conn = call(TestPlug, [auth_header("Hacker:SecretPass")])
+    assert_unauthorized conn, "Secret"
+  end
+
+  test "request with invalid password" do
+    conn = call(TestPlug, [auth_header("Admin:ASecretPass")])
+    assert_unauthorized conn, "Secret"
+  end
+
+  test "request with valid credentials" do
+    conn = call(TestPlug, [auth_header("Admin:SecretPass")])
+    assert_authorized conn, "Authorized"
+  end
+
+  test "request with malformed credentials" do
+    conn = call(TestPlug, [{"authorization", "Basic Zm9)"}])
+    assert_unauthorized conn, "Secret"
+  end
+
+  test "request with wrong scheme" do
+    conn = call(TestPlug, [{"authorization", "Bearer #{Base.encode64("Admin:SecretPass")}"}])
+    assert_unauthorized conn, "Secret"
+  end
+end


### PR DESCRIPTION
Just added the code to allow other credential stores that follow a behaviour to be used with plug_auth.

To used it, create your own CredentialStore that implement the `PlugAuth.CredentialBehaviour`, like so:

``` elixir
defmodule TestStore do
  @behaviour PlugAuth.CredentialBehaviour

  def get_user_data(_key), do: %{role: :secret_area} 
  # use your db, agent, or other logic to get data. 
  # Make sure to return a map that represent the realm that the user may access.

  # those two aren't really needed, but i've kept them to mimic current Store structure
  def put_credentials(_key, _value), do: :ok
  def delete_credentials(_key), do: %{role: :admin}
end
```

Not sure also if those two functions (`put_credentials/2` and `delete_credentials/1` should be there. What you think?

The test for the new feature repeated a lot of code of the existing test, if that is a problem we can talk about refactoring that!
