### PR TITLE
Allow skipping authentication internally

### DIFF
--- a/lib/plug_auth/authentication/basic.ex
+++ b/lib/plug_auth/authentication/basic.ex
@@ -25,10 +25,14 @@ defmodule PlugAuth.Authentication.Basic do
   end
 
   def call(conn, opts) do
-    conn
-    |> get_auth_header
-    |> verify_creds(opts[:store])
-    |> assert_creds(opts[:realm], opts[:error], opts[:assign_key])
+    if get_authenticated_user(conn) do
+      conn
+    else
+      conn
+      |> get_auth_header
+      |> verify_creds(opts[:store])
+      |> assert_creds(opts[:realm], opts[:error], opts[:assign_key])
+    end
   end
 
   defp get_auth_header(conn), do: {conn, get_first_req_header(conn, "authorization")}

--- a/lib/plug_auth/authentication/basic.ex
+++ b/lib/plug_auth/authentication/basic.ex
@@ -25,7 +25,7 @@ defmodule PlugAuth.Authentication.Basic do
   end
 
   def call(conn, opts) do
-    if get_authenticated_user(conn) do
+    if get_authenticated_user(conn, opts[:assign_key]) do
       conn
     else
       conn

--- a/lib/plug_auth/authentication/token.ex
+++ b/lib/plug_auth/authentication/token.ex
@@ -49,11 +49,15 @@ defmodule PlugAuth.Authentication.Token do
   def get_token_from_session(conn, param), do: {conn, get_session(conn, param)}
 
   def call(conn, opts) do
-    {module, fun, args} = opts[:source]
+    if get_authenticated_user(conn) do
+      conn
+    else
+      {module, fun, args} = opts[:source]
 
-    apply(module, fun, [conn | args])
-    |> verify_creds(opts[:store])
-    |> assert_creds(opts[:error], opts[:assign_key])
+      apply(module, fun, [conn | args])
+      |> verify_creds(opts[:store])
+      |> assert_creds(opts[:error], opts[:assign_key])
+    end
   end
 
   defp verify_creds({conn, creds}, store), do: {conn, store.get_user_data(creds)}

--- a/lib/plug_auth/authentication/token.ex
+++ b/lib/plug_auth/authentication/token.ex
@@ -49,7 +49,7 @@ defmodule PlugAuth.Authentication.Token do
   def get_token_from_session(conn, param), do: {conn, get_session(conn, param)}
 
   def call(conn, opts) do
-    if get_authenticated_user(conn) do
+    if get_authenticated_user(conn, opts[:assign_key]) do
       conn
     else
       {module, fun, args} = opts[:source]

--- a/test/plug_auth/authentication/basic_test.exs
+++ b/test/plug_auth/authentication/basic_test.exs
@@ -67,4 +67,14 @@ defmodule PlugAuth.Authentication.Basic.Test do
     conn = call(TestPlug, "Bearer #{Base.encode64("Admin:SecretPass")}")
     assert_unauthorized conn, "Secret"
   end
+
+  test "can skip authentication internally" do
+    conn =
+      conn(:get, "/", [])
+      |> assign(:authenticated_user, %{role: :admin})
+      |> TestPlug.call([])
+
+    assert_authorized conn, "Authorized"
+    refute conn.halted
+  end
 end

--- a/test/plug_auth/authentication/token_test.exs
+++ b/test/plug_auth/authentication/token_test.exs
@@ -82,4 +82,14 @@ defmodule PlugAuth.Authentication.Token.Test do
     conn = call(ParamPlug, [auth_param("secret_token")])
     assert_authorized conn, "Authorized"
   end
+
+  test "can skip authentication internally" do
+    conn =
+      conn(:get, "/", [])
+      |> assign(:authenticated_user, %{role: :admin})
+      |> ParamPlug.call([])
+
+    assert_authorized conn, "Authorized"
+    refute conn.halted
+  end
 end


### PR DESCRIPTION
This is useful for controller tests. The test
can assign `:authenticated_user` on `setup/1` so the
auth plug gets silently bypassed.

Having a large API underneath the `PlugAuth` with a custom store, 
I find the need of setting up accounts etc. cumbersome.
