### PR TITLE
allow functions as error handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To perform authentication, you can add either plug to your pipeline.
 ```elixir
 plug PlugAuth.Authentication.Basic, realm: "Secret"
 ```
-The realm parameter is optional and can be omitted. By default "Restricted Area" will be used as realm name. You can also pass the error parameter, which should be a string and will be sent instead of the default message "HTTP Authentication Required" on authentication failure (with status code 401).
+The realm parameter is optional and can be omitted. By default "Restricted Area" will be used as realm name. You can also pass the error parameter, which should be a string or a function. If a string is passed, that string will be sent instead of the default message "HTTP Authentication Required" on authentication failure (with status code 401). If a function is passed, that function will be called with one argument, `conn`.
 
 ### Token Example
 ```elixir
@@ -129,7 +129,28 @@ defmodule BasicWithTokenPlug do
 end
 ```
 
+## Redirect Example
+You may wish to redirect unauthorized users to a login page. This can be achieved by passing a function to the error parameter of a plug. This works for `PlugAuth.Authentication`'s `Basic` and `Token` as well as `PlugAuth.Access.Role`. The function cannot be private. The following example demonstrates a simple implementation of this:
 
+```elixir
+defmodule RedirectPlug do
+  use Plug.Builder
+  import Plug.Conn
+
+  plug PlugAuth.Authentication.Basic,
+    realm: "Secret",
+    error: &RedirectPlug.unauthorized/1
+  plug :index
+
+  @doc """
+    Redirect an unauthorized user to the login page.
+  """
+  def unauthorized(conn), do: conn |> redirect(to: "/login")
+
+  defp index(conn, _opts), do: send_resp(conn, 200, "Authorized")
+end
+
+```
 
 ## License
 Copyright (c) 2014, Bitgamma OÜ <opensource@bitgamma.com>

--- a/lib/plug_auth/access/role.ex
+++ b/lib/plug_auth/access/role.ex
@@ -34,7 +34,7 @@ defmodule PlugAuth.Access.Role do
     end
   end
 
-  def halt_forbidden(conn, error) when is_function(error) do
+  defp halt_forbidden(conn, error) when is_function(error) do
     error.(conn)
     |> halt
   end

--- a/lib/plug_auth/access/role.ex
+++ b/lib/plug_auth/access/role.ex
@@ -1,11 +1,11 @@
 defmodule PlugAuth.Access.Role do
   @moduledoc """
     Implements role-based access control. Authentication must occur before access control.
-    
+
     ## Example:
       plug PlugAuth.Authentication.Basic, realm: "Secret world"
       plug PlugAuth.Access.Role, roles: [:admin]
-  """ 
+  """
 
   @behaviour Plug
   import Plug.Conn
@@ -34,9 +34,13 @@ defmodule PlugAuth.Access.Role do
     end
   end
 
+  def halt_forbidden(conn, error) when is_function(error) do
+    error.(conn)
+    |> halt
+  end
   defp halt_forbidden(conn, error) do
     conn
-    |> send_resp(403, error) 
+    |> send_resp(403, error)
     |> halt
   end
 end

--- a/lib/plug_auth/authentication/utils.ex
+++ b/lib/plug_auth/authentication/utils.ex
@@ -9,14 +9,18 @@ defmodule PlugAuth.Authentication.Utils do
     conn.assigns[key]
   end
 
-  def halt_with_error(conn, msg \\ "unauthorized") do
-    conn 
-    |> send_resp(401, msg) 
+  def halt_with_error(conn, error) when is_function(error) do
+    error.(conn)
+    |> halt
+  end
+  def halt_with_error(conn, error \\ "unauthorized") do
+    conn
+    |> send_resp(401, error)
     |> halt
   end
 
   def get_first_req_header(conn, header), do: get_req_header(conn, header) |> header_hd
-  
+
   defp header_hd([]), do: nil
   defp header_hd([head | _]), do: head
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"cowboy": {:hex, :cowboy, "1.0.2", "876a2f63eaa5da5bd0610569d6402cabef8b3f48171233c11cfeee9f37d1f0c9", [:rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
-  "cowlib": {:hex, :cowlib, "1.0.1", "175a633c472058bbeb1b238a6409766a48b52b43b7b687ed70f03cf6e854b7d9", [:make], []},
-  "earmark": {:hex, :earmark, "0.2.0", "bc1636bc2efa0c1c172a5bcbf7c8eb73632d8c4512a6c2dac02d2ae454750af6", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.11.2", "8ac82c6144a27faca6a623eeebfbf5a791bc20a54ce29a9c02e499536d253d9b", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "plug": {:hex, :plug, "1.0.0", "dfb6e50cebdde4dd338d175df9b067e8e2e3a34e8b7b61aba6f5213cf7d13000", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
-  "ranch": {:hex, :ranch, "1.1.0", "f7ed6d97db8c2a27cca85cacbd543558001fc5a355e93a7bff1e9a9065a8545b", [:make], []}}
+%{"cowboy": {:hex, :cowboy, "1.0.2"},
+  "cowlib": {:hex, :cowlib, "1.0.1"},
+  "earmark": {:hex, :earmark, "0.2.0"},
+  "ex_doc": {:hex, :ex_doc, "0.11.2"},
+  "plug": {:hex, :plug, "1.0.0"},
+  "ranch": {:hex, :ranch, "1.1.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"cowboy": {:hex, :cowboy, "1.0.2"},
-  "cowlib": {:hex, :cowlib, "1.0.1"},
-  "earmark": {:hex, :earmark, "0.2.0"},
-  "ex_doc": {:hex, :ex_doc, "0.11.2"},
-  "plug": {:hex, :plug, "1.0.0"},
-  "ranch": {:hex, :ranch, "1.1.0"}}
+%{"cowboy": {:hex, :cowboy, "1.0.2", "876a2f63eaa5da5bd0610569d6402cabef8b3f48171233c11cfeee9f37d1f0c9", [:rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowlib": {:hex, :cowlib, "1.0.1", "175a633c472058bbeb1b238a6409766a48b52b43b7b687ed70f03cf6e854b7d9", [:make], []},
+  "earmark": {:hex, :earmark, "0.2.0", "bc1636bc2efa0c1c172a5bcbf7c8eb73632d8c4512a6c2dac02d2ae454750af6", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.2", "8ac82c6144a27faca6a623eeebfbf5a791bc20a54ce29a9c02e499536d253d9b", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "plug": {:hex, :plug, "1.0.0", "dfb6e50cebdde4dd338d175df9b067e8e2e3a34e8b7b61aba6f5213cf7d13000", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
+  "ranch": {:hex, :ranch, "1.1.0", "f7ed6d97db8c2a27cca85cacbd543558001fc5a355e93a7bff1e9a9065a8545b", [:make], []}}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,11 @@
+defmodule PlugAuth.TestHelpers do
+  import Plug.Conn
+
+  def handler(conn) do
+    conn
+    |> assign(:error_handler_called, true)
+    |> send_resp(418, "I'm a teapot")
+  end
+end
+
 ExUnit.start()


### PR DESCRIPTION
This PR adds the ability to assign a function that takes one argument, `conn`, to `:error` in plugs. This allows for more sophisticated behavior when bad requests are made (for example, using `redirect` to bounce a user back to the login page, or using `render` to present a template).
