### PR TITLE
Remove noisy Elixir 1.4 warnings from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule PlugAuth.Mixfile do
       app: :plug_auth,
       version: "1.1.0",
       elixir: "~> 1.1",
-      deps: deps,
-      package: package,
-      description: description,
+      deps: deps(),
+      package: package(),
+      description: description(),
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},


### PR DESCRIPTION
Fixes Elixir 1.4 warnings in mix.exs

![plug_auth_warnings](https://user-images.githubusercontent.com/86996/26999519-4d85e9b2-4d50-11e7-9ab7-8653c73b7c39.png)
